### PR TITLE
fix malicious path problem on windows on node.js 0.11

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,6 +111,12 @@ exports = module.exports = function serveIndex(root, options){
     // null byte(s), bad request
     if (~path.indexOf('\0')) return next(createError(400));
 
+    var isWin = ~process.platform.indexOf('win');
+    if(isWin){
+      path = path.toLowerCase();
+      root = root.toLowerCase();
+    }
+
     // malicious path
     if (path.substr(0, root.length) !== root) {
       debug('malicious path "%s"', path);


### PR DESCRIPTION
node repl

```
> process.platform
'win32'
> process.cwd()
'C:\\Users\\Administrator'
> path.resolve('desktop')
'C:\\Users\\Administrator\\desktop'
> path.join('C:\\Users\\Administrator','desktop')
'c:\\Users\\Administrator\\desktop'
```
- path.resolve ruturns `C` uppercase
- path.join returns `c` lowercase

That cause `if (path.substr(0, root.length) !== root)` fails on win7 even when path starts with root,but path with lowercase & root uppercase. Error message shows like `Forbidden`.
