### PR TITLE
allow returning file details in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ the express example).
 
 Serve index accepts these properties in the options object.
 
+
 ##### filter
 
 Apply this filter function to files. Defaults to `false`. The `filter` function
@@ -49,6 +50,17 @@ Display hidden (dot) files. Defaults to `false`.
 ##### icons
 
 Display icons. Defaults to `false`.
+
+##### jsonStats
+
+Enables detailed information to be served via JSON when the request header includes `Accept: application/json`. Defaults to `false`.
+
+When this flag is disabled, JSON requests will return a simple array of filenames. With this flag enabled, JSON requests will return an array of objects, each containing objects with the following properties:
+
+  - `name` is the relative name for the file.
+  - `stat` is subset of the `fs.Stats` object for the file.
+
+The following "safe" properties will be present as file stats: `isFile`,`isDirectory`,`size`, `atime`, `mtime`, `ctime` and `birthtime`.
 
 ##### stylesheet
 


### PR DESCRIPTION
I'm proposing a patch that allows `fs.Stats` file info to be returned in JSON. This is be enabled by the `jsonStat` option. The stat fields properties are screened to only pass a machine-neutral subset (ie. not exposing user ids, device ids, etc.). Also, the `isFile()` and `isDirectory()` function return values are encoded as properties.

Any thoughts on this? 
