### PR TITLE
EPERM and EBUSY errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,8 +518,12 @@ function stat(dir, files, cb) {
   files.forEach(function(file){
     batch.push(function(done){
       fs.stat(join(dir, file), function(err, stat){
-        if (err && err.code !== 'ENOENT') return done(err);
-
+        if (err &&
+          err.code !== 'ENOENT' &&
+          err.code !== 'EPERM' &&
+          err.code !== 'EBUSY' ){
+          return done(err);
+        }
         // pass ENOENT as null stat, not error
         done(null, stat || null);
       });


### PR DESCRIPTION
EPERM and EBUSY now passing as null, not error in function stat
