### PR TITLE
Allow to disable method restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ provided locals:
 
 Display mode. `tiles` and `details` are available. Defaults to `tiles`.
 
+##### disableMethodRestriction
+
+By default, `serve-index` restricts request methods to GET, HEAD, and OPTIONS by terminating the request via `res.end()`. However, this terminates any following middleware (e.g. a fallback proxy) as well. To prevent this, you can set the option `disableMethodRestriction` to something truthy.
+
 ## Examples
 
 ### Serve directory indexes with vanilla node.js http server

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function serveIndex(root, options) {
   var view = opts.view || 'tiles';
 
   return function (req, res, next) {
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
+    if (req.method !== 'GET' && req.method !== 'HEAD' && !opts.disableMethodRestriction) {
       res.statusCode = 'OPTIONS' === req.method ? 200 : 405;
       res.setHeader('Allow', 'GET, HEAD, OPTIONS');
       res.setHeader('Content-Length', '0');

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,16 @@ describe('serveIndex(root)', function () {
     .expect(405, done)
   })
 
+  it('should not deny POST requests in case method restriction is disabled', function (done) {
+    var server = createServer(fixtures, {
+      disableMethodRestriction: true
+    })
+
+    request(server)
+    .post('/')
+    .expect(200, done)
+  })
+
   it('should deny path will NULL byte', function (done) {
     var server = createServer()
 


### PR DESCRIPTION
By default, `serve-index` restricts request methods to GET, HEAD, and OPTIONS by terminating the request via `res.end()`. However, this terminates any following middleware (e.g. a fallback proxy) as well. This PR implements the new option `disableMethodRestriction`, allowing to prevent this.
