### PR TITLE
Add ability to include Javascript.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var serveIndex = require('serve-index')
 
 ### serveIndex(path, options)
 
-Returns middlware that serves an index of the directory in the given `path`.
+Returns middleware that serves an index of the directory in the given `path`.
 
 The `path` is based off the `req.url` value, so a `req.url` of `'/some/dir`
 with a `path` of `'public'` will look at `'public/some/dir'`. If you are using
@@ -57,6 +57,10 @@ Display icons. Defaults to `false`.
 ##### stylesheet
 
 Optional path to a CSS stylesheet. Defaults to a built-in stylesheet.
+
+##### javascript
+
+Optional path to a Javascript file. Defaults to a built-in empty file.
 
 ##### template
 

--- a/public/default.js
+++ b/public/default.js
@@ -1,0 +1,2 @@
+// This file is empty.
+// You can include your own JS via the "javascript" option.

--- a/public/directory.html
+++ b/public/directory.html
@@ -71,6 +71,7 @@
         $('search').on('keyup', search);
       });
     </script>
+    <script>{javascript}</script>
   </head>
   <body class="directory">
     <input id="search" type="text" placeholder="Search" autocomplete="off" />


### PR DESCRIPTION
If you can say

```Javascript
var index = serveIndex('public/ftp', {'style': "somefile.css"})
```

then you really ought to be able to say

```Javascript
var index = serveIndex('public/ftp', {'javascript': "somefile.js"})
```

too, and have your own JS included on every page.

Note...  I haven't tested this (can't figure out how to run the test, and don't have the time to work it out right now).  Feel free to simply discard this PR and treat it more like a feature request.