### PR TITLE
Update debug module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "accepts": "~1.3.3",
     "batch": "0.6.0",
-    "debug": "2.6.3",
+    "debug": "2.6.4",
     "escape-html": "~1.0.3",
     "http-errors": "~1.6.1",
     "mime-types": "~2.1.15",


### PR DESCRIPTION
This version fixes the issue described here https://github.com/visionmedia/debug/issues/443
> If process.env.DEBUG is set to a value other than a string a TypeError occurs. This can easily happen when using webpack to build a project.