### PR TITLE
Add option to provide custom file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ provided locals:
 
 Display mode. `tiles` and `details` are available. Defaults to `tiles`.
 
+##### fs
+
+Optional custom implementation of the [Node.js `fs` interface](https://nodejs.org/api/fs.html).
+Defaults to the standard Node.js file system ("fs").
+
+The supplied file system will be used for collecting the directory contents only. It will not be used to read static
+files like a stylesheet provided by the stylesheet option or for module internal file system operations.
+
 ## Examples
 
 ### Serve directory indexes with vanilla node.js http server


### PR DESCRIPTION
## Motivation
We would like to use serve-index on a "virtual" file system which abstracts a physical directory structure. For example, directories on different physical locations may be joined together and presented as a single directory with the content of both.

## Prior art
A popular module already providing an option to supply a custom file system is [webpack](https://webpack.js.org/api/node/#custom-file-systems) which also offers a [memory-fs](https://github.com/webpack/memory-fs) module.
A popular alternative fs implementation is for example [graceful-fs](https://github.com/isaacs/node-graceful-fs).  


CC: @matz3

