### PR TITLE
I found an issue while building personalized templates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,9 @@ serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path
       // render html
       render(locals, function (err, body) {
         if (err) return next(err);
-        send(res, 'text/html', body)
+        if (res._header === null) {
+          send(res, 'text/html', body)
+        }
       });
     });
   });


### PR DESCRIPTION
Header cannot be set!

This minor check does noting to the overall expected outcome of indexing the directory, however, while leveraging something like a middleware tool to render HTML for an index page, I found that without this minor catch, express falts calling a header error.