### PR TITLE
stat files before serveIndex, also output date, size, and type

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
  */
 
 var accepts = require('accepts');
+var bytes = require('bytes')
 var createError = require('http-errors');
 var debug = require('debug')('serve-index');
 var escapeHtml = require('escape-html');
@@ -255,7 +256,7 @@ serveIndex.plain = function _plain(req, res, dir, files) {
   // include size and date
   var nodes = files.map(function (file) {
     // human readable
-    var size = hsize(file.size)
+    var size = bytes(file.size)
 
     return [
       file.lastModified.toISOString(),
@@ -541,21 +542,6 @@ function send (res, type, body) {
   // body
   res.end(body, 'utf8')
 }
-
-/**
- * Convert size to human-readable size
- */
-
-var SIZES = [ 'B', 'K', 'M', 'G', 'T', 'P', 'E' ]
-function hsize(size) {
-  var i = 0
-  while (size > 1024 && i < SIZES.length) {
-    size = Math.floor(size/1024)
-    i += 1
-  }
-  return size + SIZES[i]
-}
-
 
 /**
  * Stat all files and return array of stat

--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ function createHtmlFileList(files, dir, useIcons, view) {
   html += files.map(function (file) {
     var classes = [];
     var isDir = file.stat && file.stat.isDirectory();
-    var path = dir.name.split('/').map(function (c) { return encodeURIComponent(c); });
+    var path = dir.split('/').map(function (c) { return encodeURIComponent(c); });
 
     if (useIcons) {
       classes.push('icon');

--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ serveIndex.json = function _json(req, res, directory, nodes) {
 
 serveIndex.plain = function _plain(req, res, dir, files) {
   var directory = {
-    name: dir.name.replace(/\/$/, '\/')
+    name: dir.name.replace(/\/?$/, '/')
   };
 
   // include size and date

--- a/index.js
+++ b/index.js
@@ -108,13 +108,6 @@ function serveIndex(root, options) {
       return;
     }
 
-    // content-negotiation
-    var accept = accepts(req);
-    var type = accept.type(mediaTypes);
-
-    // not acceptable
-    if (!type) return next(createError(406));
-
     // parse URLs
     var url = parseUrl(req);
     var originalUrl = parseUrl.original(req);
@@ -151,6 +144,13 @@ function serveIndex(root, options) {
       }
 
       if (!stat.isDirectory()) return next();
+
+      // content-negotiation
+      var accept = accepts(req);
+      var type = accept.type(mediaTypes);
+
+      // not acceptable
+      if (!type) return next(createError(406));
 
       // fetch files
       debug('readdir "%s"', path);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "accepts": "~1.3.4",
     "batch": "0.6.1",
+    "bytes": "^3.0.0",
     "debug": "2.6.9",
     "escape-html": "~1.0.3",
     "http-errors": "~1.6.2",

--- a/test/test.js
+++ b/test/test.js
@@ -436,7 +436,9 @@ describe('serveIndex(root)', function () {
       it('should provide "fileList" local', function (done) {
         var server = createServer(fixtures, {'template': function (locals, callback) {
           callback(null, JSON.stringify(locals.fileList.map(function (file) {
-            file.stat = file.stat instanceof fs.Stats;
+            file.type = -1 !== file.type.indexOf('/')
+            file.size = file.size >= 0
+            file.lastModified = file.lastModified instanceof Date
             return file;
           })));
         }});
@@ -444,7 +446,7 @@ describe('serveIndex(root)', function () {
         request(server)
         .get('/users/')
         .set('Accept', 'text/html')
-        .expect('[{"name":"..","stat":true},{"name":"#dir","stat":true},{"name":"index.html","stat":true},{"name":"tobi.txt","stat":true}]')
+        .expect('[{"name":"..","type":true,"size":true,"lastModified":true},{"name":"#dir","type":true,"size":true,"lastModified":true},{"name":"index.html","type":true,"size":true,"lastModified":true},{"name":"tobi.txt","type":true,"size":true,"lastModified":true}]')
         .expect(200, done);
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -504,9 +504,9 @@ describe('serveIndex(root)', function () {
       it('should get file list', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files) {
+        serveIndex.html = function (req, res, dir, files) {
           var text = files
-            .filter(function (f) { return /\.txt$/.test(f) })
+            .filter(function (f) { return /\.txt$/.test(f.name) })
             .sort()
           res.setHeader('Content-Type', 'text/html')
           res.end('<b>' + text.length + ' text files</b>')
@@ -521,9 +521,9 @@ describe('serveIndex(root)', function () {
       it('should get dir name', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir) {
+        serveIndex.html = function (req, res, dir, files, next) {
           res.setHeader('Content-Type', 'text/html')
-          res.end('<b>' + dir + '</b>')
+          res.end('<b>' + dir.name + '</b>')
         }
 
         request(server)
@@ -535,7 +535,7 @@ describe('serveIndex(root)', function () {
       it('should get template path', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir, showUp, icons, path, view, template) {
+        serveIndex.html = function (req, res, dir, files, next, showUp, icons, path, view, template) {
           res.setHeader('Content-Type', 'text/html')
           res.end(String(fs.existsSync(template)))
         }
@@ -549,7 +549,7 @@ describe('serveIndex(root)', function () {
       it('should get template with tokens', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir, showUp, icons, path, view, template) {
+        serveIndex.html = function (req, res, dir, files, next, showUp, icons, path, view, template) {
           res.setHeader('Content-Type', 'text/html')
           res.end(fs.readFileSync(template, 'utf8'))
         }
@@ -567,7 +567,7 @@ describe('serveIndex(root)', function () {
       it('should get stylesheet path', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir, showUp, icons, path, view, template, stylesheet) {
+        serveIndex.html = function (req, res, dir, files, next, showUp, icons, path, view, template, stylesheet) {
           res.setHeader('Content-Type', 'text/html')
           res.end(String(fs.existsSync(stylesheet)))
         }


### PR DESCRIPTION
As discussed in https://github.com/expressjs/serve-index/issues/73 this PR moves the `stat`ing of files into `serveIndex` so that `serveIndex.plain`, `serveIndex.json`, and `serveIndex.html` consistently output the same data

~~This does not yet include the updates to the tests.~~ Tests are passing.

Also addresses https://github.com/expressjs/serve-index/pull/39