### PR TITLE
Use option object for serveIndex[type]

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,20 @@ function serveIndex(root, options) {
             }
           })
 
-          serveIndex[mediaType[type]](req, res, directory, nodes, next, showUp, icons, path, view, template, stylesheet)
+          serveIndex[mediaType[type]](req, res, directory, nodes, next, {
+            // whether '..' should be shown
+            hasParent: showUp,
+            // whether to show icons
+            icons: icons,
+            // actual fs path
+            path: path,
+            // tiles or details
+            view: view,
+            // path to template
+            template: template,
+            // path to stylesheet
+            stylesheet: stylesheet
+          })
         });
       });
     });
@@ -208,7 +221,13 @@ function serveIndex(root, options) {
  * Respond with text/html.
  */
 
-serveIndex.html = function _html(req, res, directory, files, next, showUp, icons, path, view, template, stylesheet) {
+serveIndex.html = function _html(req, res, directory, files, next, options) {
+  var showUp = options.hasParant
+  var icons = options.icons
+  var path = options.path
+  var view = options.view
+  var template = options.template
+  var stylesheet = options.stylesheet
   var render = typeof template !== 'function'
     ? createHtmlRender(template)
     : template

--- a/index.js
+++ b/index.js
@@ -154,13 +154,38 @@ function serveIndex(root, options) {
         });
         files.sort();
 
+        // add parent directory as first
+        if (showUp) {
+          files.unshift('..');
+        }
+
         // content-negotiation
         var accept = accepts(req);
         var type = accept.type(mediaTypes);
 
         // not acceptable
         if (!type) return next(createError(406));
-        serveIndex[mediaType[type]](req, res, files, next, originalDir, showUp, icons, path, view, template, stylesheet);
+
+        // stat all files
+        fstat(path, files, function (err, stats) {
+          if (err) return next(err);
+
+          // combine the stats into the file list
+          var fileList = files.map(function (file, i) {
+            return { name: file, stat: stats[i] };
+          });
+
+          // sort file list
+          fileList.sort(fileSort);
+
+          // make similar to file object (with stat)
+          var directory = {
+            name: originalDir,
+            stat: stat
+          }
+
+          serveIndex[mediaType[type]](req, res, directory, fileList, next, showUp, icons, path, view, template, stylesheet);
+        });
       });
     });
   };
@@ -170,46 +195,29 @@ function serveIndex(root, options) {
  * Respond with text/html.
  */
 
-serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path, view, template, stylesheet) {
+serveIndex.html = function _html(req, res, directory, files, next, showUp, icons, path, view, template, stylesheet) {
   var render = typeof template !== 'function'
     ? createHtmlRender(template)
     : template
 
-  if (showUp) {
-    files.unshift('..');
-  }
-
-  // stat all files
-  stat(path, files, function (err, stats) {
+  // read stylesheet
+  fs.readFile(stylesheet, 'utf8', function (err, style) {
     if (err) return next(err);
 
-    // combine the stats into the file list
-    var fileList = files.map(function (file, i) {
-      return { name: file, stat: stats[i] };
-    });
+    // create locals for rendering
+    var locals = {
+      directory: directory.name,
+      displayIcons: Boolean(icons),
+      fileList: files,
+      path: path,
+      style: style,
+      viewName: view
+    };
 
-    // sort file list
-    fileList.sort(fileSort);
-
-    // read stylesheet
-    fs.readFile(stylesheet, 'utf8', function (err, style) {
+    // render html
+    render(locals, function (err, body) {
       if (err) return next(err);
-
-      // create locals for rendering
-      var locals = {
-        directory: dir,
-        displayIcons: Boolean(icons),
-        fileList: fileList,
-        path: path,
-        style: style,
-        viewName: view
-      };
-
-      // render html
-      render(locals, function (err, body) {
-        if (err) return next(err);
-        send(res, 'text/html', body)
-      });
+      send(res, 'text/html', body)
     });
   });
 };
@@ -218,24 +226,26 @@ serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path
  * Respond with application/json.
  */
 
-serveIndex.json = function _json(req, res, files) {
+serveIndex.json = function _json(req, res, directory, nodes) {
+  var files = nodes.map(function (file) { return file.name })
   send(res, 'application/json', JSON.stringify(files))
-};
+}
 
 /**
  * Respond with text/plain.
  */
 
-serveIndex.plain = function _plain(req, res, files) {
+serveIndex.plain = function _plain(req, res, directory, nodes) {
+  var files = nodes.map(function (file) { return file.name })
   send(res, 'text/plain', (files.join('\n') + '\n'))
-};
+}
 
 /**
  * Map html `files`, returning an html unordered list.
  * @private
  */
 
-function createHtmlFileList(files, dir, useIcons, view) {
+function createHtmlFileList(files, dirname, useIcons, view) {
   var html = '<ul id="files" class="view-' + escapeHtml(view) + '">'
     + (view === 'details' ? (
       '<li class="header">'
@@ -247,7 +257,7 @@ function createHtmlFileList(files, dir, useIcons, view) {
   html += files.map(function (file) {
     var classes = [];
     var isDir = file.stat && file.stat.isDirectory();
-    var path = dir.split('/').map(function (c) { return encodeURIComponent(c); });
+    var path = dirname.split('/').map(function (c) { return encodeURIComponent(c); });
 
     if (useIcons) {
       classes.push('icon');
@@ -511,7 +521,7 @@ function send (res, type, body) {
  * in same order.
  */
 
-function stat(dir, files, cb) {
+function fstat(dir, files, cb) {
   var batch = new Batch();
 
   batch.concurrency(10);

--- a/test/test.js
+++ b/test/test.js
@@ -504,9 +504,9 @@ describe('serveIndex(root)', function () {
       it('should get file list', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files) {
+        serveIndex.html = function (req, res, directory, files) {
           var text = files
-            .filter(function (f) { return /\.txt$/.test(f) })
+            .filter(function (f) { return /\.txt$/.test(f.name) })
             .sort()
           res.setHeader('Content-Type', 'text/html')
           res.end('<b>' + text.length + ' text files</b>')
@@ -521,9 +521,9 @@ describe('serveIndex(root)', function () {
       it('should get dir name', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir) {
+        serveIndex.html = function (req, res, directory, files, next) {
           res.setHeader('Content-Type', 'text/html')
-          res.end('<b>' + dir + '</b>')
+          res.end('<b>' + directory.name + '</b>')
         }
 
         request(server)
@@ -535,7 +535,7 @@ describe('serveIndex(root)', function () {
       it('should get template path', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir, showUp, icons, path, view, template) {
+        serveIndex.html = function (req, res, directory, files, next, showUp, icons, path, view, template) {
           res.setHeader('Content-Type', 'text/html')
           res.end(String(fs.existsSync(template)))
         }
@@ -549,7 +549,7 @@ describe('serveIndex(root)', function () {
       it('should get template with tokens', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir, showUp, icons, path, view, template) {
+        serveIndex.html = function (req, res, directory, files, next, showUp, icons, path, view, template) {
           res.setHeader('Content-Type', 'text/html')
           res.end(fs.readFileSync(template, 'utf8'))
         }
@@ -567,7 +567,7 @@ describe('serveIndex(root)', function () {
       it('should get stylesheet path', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, files, next, dir, showUp, icons, path, view, template, stylesheet) {
+        serveIndex.html = function (req, res, directory, files, next, showUp, icons, path, view, template, stylesheet) {
           res.setHeader('Content-Type', 'text/html')
           res.end(String(fs.existsSync(stylesheet)))
         }
@@ -585,7 +585,7 @@ describe('serveIndex(root)', function () {
       it('should get called with Accept: text/plain', function (done) {
         var server = createServer()
 
-        serveIndex.plain = function (req, res, files) {
+        serveIndex.plain = function (req, res, directory, files) {
           res.setHeader('Content-Type', 'text/plain');
           res.end('called');
         }
@@ -603,7 +603,7 @@ describe('serveIndex(root)', function () {
       it('should get called with Accept: application/json', function (done) {
         var server = createServer()
 
-        serveIndex.json = function (req, res, files) {
+        serveIndex.json = function (req, res, directory, files) {
           res.setHeader('Content-Type', 'application/json');
           res.end('"called"');
         }

--- a/test/test.js
+++ b/test/test.js
@@ -436,7 +436,9 @@ describe('serveIndex(root)', function () {
       it('should provide "fileList" local', function (done) {
         var server = createServer(fixtures, {'template': function (locals, callback) {
           callback(null, JSON.stringify(locals.fileList.map(function (file) {
-            file.stat = file.stat instanceof fs.Stats;
+            file.lastModified = file.lastModified instanceof Date
+            file.size = file.size >= 0
+            file.type = /\//.test(file.type)
             return file;
           })));
         }});
@@ -444,7 +446,7 @@ describe('serveIndex(root)', function () {
         request(server)
         .get('/users/')
         .set('Accept', 'text/html')
-        .expect('[{"name":"..","stat":true},{"name":"#dir","stat":true},{"name":"index.html","stat":true},{"name":"tobi.txt","stat":true}]')
+        .expect('[{"name":"..","type":true,"size":true,"lastModified":true},{"name":"#dir","type":true,"size":true,"lastModified":true},{"name":"index.html","type":true,"size":true,"lastModified":true},{"name":"tobi.txt","type":true,"size":true,"lastModified":true}]')
         .expect(200, done);
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -537,9 +537,9 @@ describe('serveIndex(root)', function () {
       it('should get template path', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, directory, files, next, showUp, icons, path, view, template) {
+        serveIndex.html = function (req, res, directory, files, next, options) {
           res.setHeader('Content-Type', 'text/html')
-          res.end(String(fs.existsSync(template)))
+          res.end(String(fs.existsSync(options.template)))
         }
 
         request(server)
@@ -551,9 +551,9 @@ describe('serveIndex(root)', function () {
       it('should get template with tokens', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, directory, files, next, showUp, icons, path, view, template) {
+        serveIndex.html = function (req, res, directory, files, next, options) {
           res.setHeader('Content-Type', 'text/html')
-          res.end(fs.readFileSync(template, 'utf8'))
+          res.end(fs.readFileSync(options.template, 'utf8'))
         }
 
         request(server)
@@ -569,9 +569,9 @@ describe('serveIndex(root)', function () {
       it('should get stylesheet path', function (done) {
         var server = createServer()
 
-        serveIndex.html = function (req, res, directory, files, next, showUp, icons, path, view, template, stylesheet) {
+        serveIndex.html = function (req, res, directory, files, next, options) {
           res.setHeader('Content-Type', 'text/html')
-          res.end(String(fs.existsSync(stylesheet)))
+          res.end(String(fs.existsSync(options.stylesheet)))
         }
 
         request(server)


### PR DESCRIPTION
Lots of the PRs involve adding options on how to change the view.

As part of moving towards having the ability to consistent output between the 3 templates (plain, json, and html), and the potential to have theme modules in the future, it seems to make sense to move towards a viewOptions object that can be passed to template functions.

```
serveIndex[mediaType[type]](req, res, directory, nodes, next, viewOptions)
```

instead of ever growing
```
serveIndex[mediaType[type]](req, res, directory, nodes, next, showUp, icons, path, view, template, stylesheet, twentyOneThing, twentyTwoThing, orangeRedThing, tourquiseBlueThing)
```