### PR TITLE
Serve HTTP 400 instead of throwing on badly encoded request URI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Show font icon for more font types
+  * Use 400 error on URI decode failure instead of 500
   * deps: accepts@~1.3.5
     - deps: mime-types@~2.1.18
   * deps: http-errors@~1.7.2

--- a/index.js
+++ b/index.js
@@ -107,10 +107,14 @@ function serveIndex(root, options) {
       return;
     }
 
+    // get dir
+    var dir = getRequestedDir(req)
+
+    // bad request
+    if (dir === null) return next(createError(400))
+
     // parse URLs
-    var url = parseUrl(req);
     var originalUrl = parseUrl.original(req);
-    var dir = decodeURIComponent(url.pathname);
     var originalDir = decodeURIComponent(originalUrl.pathname);
 
     // join / normalize from root dir
@@ -325,6 +329,22 @@ function fileSort(a, b) {
 
   return Number(b.stat && b.stat.isDirectory()) - Number(a.stat && a.stat.isDirectory()) ||
     String(a.name).toLocaleLowerCase().localeCompare(String(b.name).toLocaleLowerCase());
+}
+
+/**
+ * Get the requested directory from request.
+ *
+ * @param req
+ * @return {string}
+ * @api private
+ */
+
+function getRequestedDir (req) {
+  try {
+    return decodeURIComponent(parseUrl(req).pathname)
+  } catch (e) {
+    return null
+  }
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,14 @@ describe('serveIndex(root)', function () {
     .expect(400, done)
   })
 
+  it('should deny path that does not decode', function (done) {
+    var server = createServer()
+
+    request(server)
+      .head('/%FF')
+      .expect(400, done)
+  })
+
   it('should deny path outside root', function (done) {
     var server = createServer()
 


### PR DESCRIPTION
Wraps `decodeURIComponent` calls in a try-catch to avoid throwing to Express error handler when the request URI is not properly encoded.

Includes a test case: `HEAD /%E4` is HTTP 500 in master, this makes it HTTP 400.