### PR TITLE
Added stat-absent checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,10 +294,10 @@ function createHtmlFileList(files, dir, useIcons, view) {
 
     path.push(encodeURIComponent(file.name));
 
-    var date = file.stat && file.name !== '..'
+    var date = file.stat && file.stat.mtime && file.name !== '..'
       ? file.stat.mtime.toLocaleDateString() + ' ' + file.stat.mtime.toLocaleTimeString()
       : '';
-    var size = file.stat && !isDir
+    var size = file.stat && file.stat.size && !isDir
       ? file.stat.size
       : '';
 


### PR DESCRIPTION
Added checks for the presence of the `stat.mtime` and `stat.size` properties in the `createHtmlFileList` function.

For more details see [this issue comment](https://github.com/expressjs/serve-index/issues/101#issuecomment-907682083) for more details.