### PR TITLE
Fix 3 high severity vulnerabilities by upgrading all packages to their lastest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,20 +6,20 @@
   "license": "MIT",
   "repository": "expressjs/serve-index",
   "dependencies": {
-    "accepts": "~1.3.7",
+    "accepts": "~1.3.8",
     "batch": "0.6.1",
-    "debug": "2.6.9",
+    "debug": "4.4.0",
     "escape-html": "~1.0.3",
-    "http-errors": "~1.8.0",
-    "mime-types": "~2.1.29",
+    "http-errors": "~2.0.0",
+    "mime-types": "~2.1.35",
     "parseurl": "~1.3.3"
   },
   "devDependencies": {
     "after": "0.8.2",
-    "eslint": "7.23.0",
-    "eslint-plugin-markdown": "2.0.0",
-    "mocha": "10.4.0",
-    "nyc": "15.1.0",
+    "eslint": "9.17.0",
+    "eslint-plugin-markdown": "5.1.0",
+    "mocha": "11.0.1",
+    "nyc": "17.1.0",
     "supertest": "7.0.0"
   },
   "files": [


### PR DESCRIPTION
Running `npm install` I got:

```stdout
added 373 packages, and audited 374 packages in 18s

74 packages are looking for funding
  run `npm fund` for details

3 high severity vulnerabilities
```

I updated the packages to their last version an run tests again. 

Theres was one test failing locally in my Window 11 machine. It still fails the same way after update.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->