### PR TITLE
Replace broken links in readme with archived versions + fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var serveIndex = require('serve-index')
 
 ### serveIndex(path, options)
 
-Returns middlware that serves an index of the directory in the given `path`.
+Returns middleware that serves an index of the directory in the given `path`.
 
 The `path` is based off the `req.url` value, so a `req.url` of `'/some/dir`
 with a `path` of `'public'` will look at `'public/some/dir'`. If you are using

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ app.listen(3000)
 
 ## License
 
-[MIT](LICENSE). The [Silk](http://www.famfamfam.com/lab/icons/silk/) icons
-are created by/copyright of [FAMFAMFAM](http://www.famfamfam.com/).
+[MIT](LICENSE). The [Silk](https://web.archive.org/web/20230105212205/http://www.famfamfam.com/lab/icons/silk/) icons
+are created by/copyright of [FAMFAMFAM](https://web.archive.org/web/20230109095739/http://www.famfamfam.com/).
 
 [appveyor-image]: https://img.shields.io/appveyor/ci/dougwilson/serve-index/master.svg?label=windows
 [appveyor-url]: https://ci.appveyor.com/project/dougwilson/serve-index


### PR DESCRIPTION
The famfamfam.com website disappeared sometime in January 2023. The author seems to have mostly [disappeared from the internet](https://luc.lino-framework.org/blog/2012/1027.html#who-is-mark-james) (there is a private [Twitter account](https://twitter.com/markjames)). The archive links point to the latest archived versions that works.

fe795ba fixes a _middlware_ typo that multiple people (and bots) have complained about in the [expressjs.com](https://github.com/expressjs/expressjs.com) repo.
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
