### PR TITLE
Support custom template locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Display hidden (dot) files. Defaults to `false`.
 
 Display icons. Defaults to `false`.
 
+##### locals
+
+Additional locals to provide to function templates. If the request has a
+`req.locals` object, those locals are merged after `options.locals`. The
+required locals listed below are merged last.
+
 ##### stylesheet
 
 Optional path to a CSS stylesheet. Defaults to a built-in stylesheet.

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ function serveIndex(root, options) {
   var filter = opts.filter;
   var hidden = opts.hidden;
   var icons = opts.icons;
+  var locals = opts.locals;
   var stylesheet = opts.stylesheet || defaultStylesheet;
   var template = opts.template || defaultTemplate;
   var view = opts.view || 'tiles';
@@ -164,7 +165,7 @@ function serveIndex(root, options) {
 
         // not acceptable
         if (!type) return next(createError(406));
-        serveIndex[mediaType[type]](req, res, files, next, originalDir, showUp, icons, path, view, template, stylesheet);
+        serveIndex[mediaType[type]](req, res, files, next, originalDir, showUp, icons, path, view, template, stylesheet, locals);
       });
     });
   };
@@ -174,7 +175,7 @@ function serveIndex(root, options) {
  * Respond with text/html.
  */
 
-serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path, view, template, stylesheet) {
+serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path, view, template, stylesheet, templateLocals) {
   var render = typeof template !== 'function'
     ? createHtmlRender(template)
     : template
@@ -195,20 +196,20 @@ serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path
       if (err) return next(err);
 
       // create locals for rendering
-      var locals = {
-        directory: dir,
-        displayIcons: Boolean(icons),
-        fileList: fileList,
-        path: path,
-        style: style,
-        viewName: view
-      };
+      var renderLocals = createLocals(templateLocals, req.locals)
+
+      renderLocals.directory = dir
+      renderLocals.displayIcons = Boolean(icons)
+      renderLocals.fileList = fileList
+      renderLocals.path = path
+      renderLocals.style = style
+      renderLocals.viewName = view
 
       // render html
-      render(locals, function (err, body) {
+      render(renderLocals, function (err, body) {
         if (err) return next(err);
         send(res, 'text/html', body)
-      }, req, res);
+      });
     });
   });
 };
@@ -259,6 +260,28 @@ serveIndex.plain = function _plain (req, res, files, next, dir, showUp, icons, p
  * Map html `files`, returning an html unordered list.
  * @private
  */
+
+function createLocals() {
+  var locals = {}
+
+  for (var i = 0; i < arguments.length; i++) {
+    mergeLocals(locals, arguments[i])
+  }
+
+  return locals
+}
+
+function mergeLocals(target, source) {
+  if (!source || typeof source !== 'object') return target
+
+  for (var prop in source) {
+    if (Object.prototype.hasOwnProperty.call(source, prop)) {
+      target[prop] = source[prop]
+    }
+  }
+
+  return target
+}
 
 function createHtmlFileList(files, dir, useIcons, view) {
   var html = '<ul id="files" class="view-' + escapeHtml(view) + '">'

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ serveIndex.html = function _html(req, res, files, next, dir, showUp, icons, path
       render(locals, function (err, body) {
         if (err) return next(err);
         send(res, 'text/html', body)
-      });
+      }, req, res);
     });
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -452,25 +452,63 @@ describe('serveIndex(root)', function () {
           .expect(200, 'This is a template.', done)
       });
 
-      it('should provide request and response arguments', function (done) {
-        var templateReq
-        var templateRes
-        var server = createServer(fixtures, {'template': function (locals, callback, req, res) {
-          templateReq = req
-          templateRes = res
-          callback(null, 'This is a template.')
-        }})
+      it('should provide "locals" option values', function (done) {
+        var server = createServer(fixtures, {
+          'locals': {'username': 'static-user'},
+          'template': function (locals, callback) {
+            callback(null, JSON.stringify(locals.username))
+          }
+        })
 
         request(server)
           .get('/users/')
           .set('Accept', 'text/html')
-          .expect(200, 'This is a template.')
-          .expect(function () {
-            assert.strictEqual(templateReq.method, 'GET')
-            assert.strictEqual(templateReq.url, '/users/')
-            assert.strictEqual(typeof templateRes.setHeader, 'function')
-          })
-          .end(done)
+          .expect(200, '"static-user"', done)
+      })
+
+      it('should provide request locals', function (done) {
+        var server = createServer(fixtures, {'template': function (locals, callback) {
+          callback(null, JSON.stringify(locals.username))
+        }}, function (req) {
+          req.locals = {'username': 'request-user'}
+        })
+
+        request(server)
+          .get('/users/')
+          .set('Accept', 'text/html')
+          .expect(200, '"request-user"', done)
+      })
+
+      it('should prefer request locals to "locals" option values', function (done) {
+        var server = createServer(fixtures, {
+          'locals': {'username': 'static-user'},
+          'template': function (locals, callback) {
+            callback(null, JSON.stringify(locals.username))
+          }
+        }, function (req) {
+          req.locals = {'username': 'request-user'}
+        })
+
+        request(server)
+          .get('/users/')
+          .set('Accept', 'text/html')
+          .expect(200, '"request-user"', done)
+      })
+
+      it('should prefer required locals to custom locals', function (done) {
+        var server = createServer(fixtures, {
+          'locals': {'directory': 'custom-directory'},
+          'template': function (locals, callback) {
+            callback(null, JSON.stringify(locals.directory))
+          }
+        }, function (req) {
+          req.locals = {'directory': 'request-directory'}
+        })
+
+        request(server)
+          .get('/users/')
+          .set('Accept', 'text/html')
+          .expect(200, '"/users/"', done)
       })
 
       it('should handle render errors', function (done) {
@@ -849,12 +887,14 @@ function alterProperty(obj, prop, val) {
   })
 }
 
-function createServer(dir, opts) {
+function createServer(dir, opts, setup) {
   dir = dir || fixtures
 
   var _serveIndex = serveIndex(dir, opts)
 
   return http.createServer(function (req, res) {
+    if (setup) setup(req, res)
+
     _serveIndex(req, res, function (err) {
       res.statusCode = err ? (err.status || 500) : 404
       res.end(err ? err.message : 'Not Found')

--- a/test/test.js
+++ b/test/test.js
@@ -452,6 +452,27 @@ describe('serveIndex(root)', function () {
           .expect(200, 'This is a template.', done)
       });
 
+      it('should provide request and response arguments', function (done) {
+        var templateReq
+        var templateRes
+        var server = createServer(fixtures, {'template': function (locals, callback, req, res) {
+          templateReq = req
+          templateRes = res
+          callback(null, 'This is a template.')
+        }})
+
+        request(server)
+          .get('/users/')
+          .set('Accept', 'text/html')
+          .expect(200, 'This is a template.')
+          .expect(function () {
+            assert.strictEqual(templateReq.method, 'GET')
+            assert.strictEqual(templateReq.url, '/users/')
+            assert.strictEqual(typeof templateRes.setHeader, 'function')
+          })
+          .end(done)
+      })
+
       it('should handle render errors', function (done) {
         var server = createServer(fixtures, {'template': function (locals, callback) {
           callback(new Error('boom!'));


### PR DESCRIPTION
Fixes #42.

This adds a way to pass additional data into custom template functions without exposing `req` or `res` to the renderer:

- `options.locals` provides static template locals.
- `req.locals` provides request-scoped locals from upstream middleware.
- Required serve-index locals are merged last so built-in rendering fields such as `directory`, `fileList`, `path`, `style`, and `viewName` cannot be overridden accidentally.

This preserves the existing template callback signature and keeps rendering independent from direct request/response side effects.

Verification:

- `./node_modules/.bin/mocha --reporter spec --check-leaks test/ --grep 'locals'`
- `npm test`
- `npm run lint`
- `git diff --check master..HEAD`
