### PR TITLE
deps: update debug from 2.6.9 to ~4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "accepts": "~1.3.8",
     "batch": "0.6.1",
-    "debug": "2.6.9",
+    "debug": "~4.4.0",
     "escape-html": "~1.0.3",
     "http-errors": "~1.8.0",
     "mime-types": "~2.1.35",


### PR DESCRIPTION
## Summary

Updates the `debug` runtime dependency from 2.6.9 (May 2017) to latest stable ~4.4.0.

## Why

- `debug@2.6.9` is **9 years old** with no security patches since 2017
- Part of expressjs middleware `debug` upgrade series (morgan#364, compression#279, session#1141)

## What Changed

| Package | Before | After |
|---------|--------|-------|
| `debug` | `2.6.9` | `~4.4.0` |

## Verification

```
npm install && npm test
```

**61 passing, 0 failures**